### PR TITLE
There is no comic sans, let's use sans-serif in iOS

### DIFF
--- a/assets/stylesheets/main.css
+++ b/assets/stylesheets/main.css
@@ -1,5 +1,5 @@
 body {
-  font-family: "Comic Sans MS", cursive, sans-serif;
+  font-family: "Comic Sans MS", sans-serif;
   background-color: mintcream;
 }
 
@@ -72,7 +72,7 @@ main {
 }
 
 .tools-toggle {
-  font-family: "Comic Sans MS", cursive, sans-serif;
+  font-family: "Comic Sans MS", sans-serif;
   background: mediumaquamarine;
 }
 .tools-toggle.active {


### PR DESCRIPTION
- Fix #11
